### PR TITLE
fix: fixes onClickOutside on iOS devices. fixes #13

### DIFF
--- a/src/Effect.tsx
+++ b/src/Effect.tsx
@@ -37,7 +37,7 @@ export function Effect(
       }
     };
 
-    const onClick = (event: MouseEvent) => {
+    const onClick = (event: MouseEvent | TouchEvent) => {
       if (event.defaultPrevented || event.target === lastEventTarget) {
         return;
       }
@@ -65,6 +65,7 @@ export function Effect(
       }
       document.addEventListener('keyup', onKeyPress);
       document.addEventListener('click', onClick);
+      document.addEventListener('touchstart', onClick);
     };
 
     const onNodeDeactivation = () => {
@@ -74,10 +75,14 @@ export function Effect(
       }
       document.removeEventListener('keyup', onKeyPress);
       document.removeEventListener('click', onClick);
+      document.removeEventListener('touchstart', onClick);
     };
 
     setLockProps({
       onClick: (e: React.MouseEvent) => {
+        lastEventTarget = e.target
+      },
+      onTouchStart: (e: React.TouchEvent) => {
         lastEventTarget = e.target
       },
       onActivation: onNodeActivation,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ import * as React from "react";
 export interface LockProps {
   onClick?(e: React.MouseEvent): void;
 
+  onTouchStart?(e: React.TouchEvent): void;
+
   onActivation?(node: HTMLElement): void;
 
   onDeactivation?(): void;


### PR DESCRIPTION
Hi @theKashey,

This is the PR I had a in mind in order to fix #13.
I am pretty sure about the addition of the `touchstart` handler.
However I wasn't sure whether or not I should add the code around the `setLockProps` (See [this](https://github.com/theKashey/react-focus-on/compare/master...benoitgrelard:onclickoutside-ios-fix?expand=1#diff-49c92e6c9336d4ef0a3df56ef3c478a4R85-R87))
It seems like it should be added but you're probably more aware of it than me.

Let me know what you think of the fix.

✌️ 