### PR TITLE
Forward the event to the onClickOutside handler

### DIFF
--- a/src/Effect.tsx
+++ b/src/Effect.tsx
@@ -49,7 +49,7 @@ export function Effect(
         return;
       }
       if (onClickOutside) {
-        onClickOutside();
+        onClickOutside(event);
       }
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface LockProps {
 
 export interface CommonProps {
   onEscapeKey?: (event: Event) => void;
-  onClickOutside?: () => void;
+  onClickOutside?: (event: MouseEvent | TouchEvent) => void;
 
   onActivation?: (node: HTMLElement) => void;
   onDeactivation?: () => void;


### PR DESCRIPTION
I added the event argument to the onCLickOutside handler so that the user can enable preventDefault etc... I had an issue where the mouse down event interfered with the click on an outside element.