### PR TITLE
feat: expose whitelist prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ import {FocusOn} from 'react-focus-on';
 --- 
  - `[autoFocus=true]` - enables or disables `auto focus` management (see [react-focus-lock documentation](https://github.com/theKashey/react-focus-lock))
  - `[returnFocus=true]` - enables or disables `return focus` on lock deactivation (see [react-focus-lock documentation](https://github.com/theKashey/react-focus-lock))
+ - `[whiteList=fn]` - you could whitelist locations FocusLock should carry about. Everything outside it will ignore. For example - any modals (see [react-focus-lock documentation](https://github.com/theKashey/react-focus-lock))
 ---
  - `[gapMode]` - the way removed ScrollBar would be _compensated_ - margin(default), or padding. See [scroll-locky documentation](https://github.com/theKashey/react-scroll-locky#gap-modes) to find the one you need.
  - `[noIsolation]` - disables aria-hidden isolation

--- a/src/UI.tsx
+++ b/src/UI.tsx
@@ -23,6 +23,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
       allowPinchZoom,
       sideCar,
       className,
+      whiteList,
       ...rest
     } = props;
 
@@ -43,6 +44,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
           onDeactivation={onDeactivation}
           className={className}
           as={RemoveScroll}
+          whiteList={whiteList}
           lockProps={{
             ...restProps,
             sideCar,

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,8 @@ export interface ReactFocusOnProps extends CommonProps {
 
   className?: string;
   children: React.ReactNode;
+
+  whiteList?: (activeElement: HTMLElement) => boolean;
 }
 
 export interface ReactFocusOnSideProps extends ReactFocusOnProps {


### PR DESCRIPTION
Exposes `whiteList` prop from `react-focus-on` for cases where ref shards cannot be used, e.g., another library that renders a dropdown into the body.