### PR TITLE
Allow `style` prop on <FocusOn />

### DIFF
--- a/example/app.tsx
+++ b/example/app.tsx
@@ -61,6 +61,7 @@ export default class App extends Component <{}, AppState> {
                   allowPinchZoom={true}
 
                   className="test-class-name"
+                  style={{color: 'inherit'}}
                 >
                   Holala!! {on ? "on" : "off"}
                   <button onClick={() => alert('ok')}>test inside event</button>

--- a/src/UI.tsx
+++ b/src/UI.tsx
@@ -23,6 +23,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
       allowPinchZoom,
       sideCar,
       className,
+      style,
       ...rest
     } = props;
 
@@ -49,7 +50,8 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
             shards,
             allowPinchZoom,
             inert,
-            enabled: enabled && scrollLock
+            style,
+            enabled: enabled && scrollLock,
           }}
         >
           {children}

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface ReactFocusOnProps extends CommonProps {
 
   className?: string;
   children: React.ReactNode;
+  style?: React.CSSProperties
 }
 
 export interface ReactFocusOnSideProps extends ReactFocusOnProps {


### PR DESCRIPTION
Closes #46 by allowing `style` to be passed through to `<ReactFocusLock />` `lockProps` from top-level `<FocusOn />`.

The resulting `style` attribute will be applied to the same `div` element targeted by the `className` prop.