### PR TITLE
define tslib as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-focus-lock": "^2.5.0",
     "react-remove-scroll": "^2.4.1",
     "react-style-singleton": "^2.1.1",
+    "tslib": "*",
     "use-callback-ref": "^1.2.5",
     "use-sidecar": "^1.0.5"
   },


### PR DESCRIPTION
Fixes https://github.com/theKashey/react-focus-on/issues/52

Defines `tslib: *` as a dependency so that it is installed if not already in use and can be mapped properly by yarn pnp.