### PR TITLE
Add support of exactOptionalPropertyTypes compiler flag

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,98 +3,98 @@ import ReactFocusLock from 'react-focus-lock/UI';
 import {ComponentProps} from "react";
 
 export interface LockProps {
-  onMouseDown?(e: React.MouseEvent): void;
+  onMouseDown?: ((e: React.MouseEvent) => void) | undefined;
 
-  onTouchStart?(e: React.TouchEvent): void;
+  onTouchStart?: ((e: React.TouchEvent) => void) | undefined;
 
-  onActivation?(node: HTMLElement): void;
+  onActivation?: ((node: HTMLElement) => void) | undefined;
 
-  onDeactivation?(): void;
+  onDeactivation?: (() => void) | undefined;
 }
 
 export interface CommonProps {
   /**
    * action to perform on Esc key press
    */
-  onEscapeKey?: (event: Event) => void;
+  onEscapeKey?: ((event: Event) => void) | undefined;
   /**
    * action to perform on click outside
    */
-  onClickOutside?: (event: MouseEvent | TouchEvent) => void;
+  onClickOutside?: ((event: MouseEvent | TouchEvent) => void) | undefined;
 
   /**
    * callback on lock activation
    * @param node the main node
    */
-  onActivation?: (node: HTMLElement) => void;
+  onActivation?: ((node: HTMLElement) => void) | undefined;
   /**
    * callback on lock deactivation
    */
-  onDeactivation?: () => void;
+  onDeactivation?: (() => void) | undefined;
 
   /**
    * [scroll-lock] control isolation
    * @see {@link https://github.com/theKashey/react-remove-scroll#usage}
    */
-  noIsolation?: boolean;
+  noIsolation?: boolean | undefined;
   /**
    * [scroll-lock] full page inert (event suppression)
    * @default false
    * @see {@link https://github.com/theKashey/react-remove-scroll#usage}
    */
-  inert?: boolean;
+  inert?: boolean | undefined;
   /**
    * [scroll-lock] allows scroll based zoom
    * @default false
    * @see https://github.com/theKashey/react-remove-scroll#usage
    */
-  allowPinchZoom?: boolean;
+  allowPinchZoom?: boolean | undefined;
 
   /**
    * a list of elements which should be considered as a part of the lock
    */
-  shards?: Array<React.RefObject<any> | HTMLElement>;
+  shards?: (Array<React.RefObject<any> | HTMLElement>) | undefined;
 }
 
 export interface ReactFocusOnProps extends CommonProps {
   /**
    * The main switch
    */
-  enabled?: boolean;
+  enabled?: boolean | undefined;
   /**
    * Controls scroll lock behavior
    */
-  scrollLock?: boolean;
+  scrollLock?: boolean | undefined;
   /**
    * Controls focus lock behavior
    */
-  focusLock?: boolean;
+  focusLock?: boolean | undefined;
 
   /**
    * [focus-lock] control autofocus
    * @default true
    */
-  autoFocus?: boolean;
+  autoFocus?: boolean | undefined;
   /**
    * [focus-lock] control returnFocus
    * @default true
    */
-  returnFocus?: ComponentProps<typeof ReactFocusLock>['returnFocus'];
+  returnFocus?: ComponentProps<typeof ReactFocusLock>['returnFocus'] | undefined;
 
   /**
    * [focus-lock] allows "ignoring" focus on some elements
    * @see {@link https://github.com/theKashey/react-focus-lock#api}
    */
-  shouldIgnore?: (candidate: HTMLElement) => boolean;
+  shouldIgnore?: ((candidate: HTMLElement) => boolean) | undefined;
 
   /**
    * allows replacement of the host node
    * @default div
    */
-  as?: string | React.ElementType;
+  as?: string | React.ElementType | undefined;
 
-  style?: React.CSSProperties;
-  className?: string;
+  style?: React.CSSProperties | undefined;
+  className?: string | undefined;
   children: React.ReactNode;
 }
 


### PR DESCRIPTION
I'm using this library in a project with [exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) enabled.

Unfortunately, currently I can't conditionally pass `undefined` into optional properties. For example, this code doesn't work:

```typescript
<FocusOn onClickOutside={closeOnOutsideClick ? onClose : undefined}>
```

This is because with the new flag, TypeScript treats missing properties and `undefined` as semantically distinct, and this library only allows for properties to be missing (but not to be set to `undefined`).

Read more about the compiler flag in [TypeScript 4.4 blog post](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#exact-optional-property-types). The intention is to migrate all type definitions to support this flag:

> We’ll be making updates to DefinitelyTyped and other definitions to try to make the transition as straightforward as possible