### PR TITLE
Remove aria-hidden=true with noIsolation behavior

### DIFF
--- a/src/Effect.tsx
+++ b/src/Effect.tsx
@@ -115,12 +115,13 @@ export function Effect({
     let unmounted = false;
 
     const onNodeActivation = (node: HTMLElement) => {
-      _undo = hideOthers(
-        [node, ...(shards || []).map(extractRef)],
-        document.body,
-        noIsolation ? undefined : focusHiddenMarker
-      );
-
+      if (!noIsolation) {
+        _undo = hideOthers(
+          [node, ...(shards || []).map(extractRef)],
+          document.body,
+          focusHiddenMarker
+        );
+      }
       setActiveNode(() => node);
     };
 


### PR DESCRIPTION
Current behavior adds aria-hidden attribute throughout the DOM with `noIsolation === true` by calling `hideOthers(refs, document.body, undefined)`.

This makes introducing the library into a codebase with existing UI testing extremely challenging, as many testing frameworks ignore subtrees with `aria-hidden="true"`, meaning as soon as react-focus-on is used, many UI tests may go red. I made this in hopes of removing that barrier to entry.