### PR TITLE
Add explicit `focusOptions` support for `ReactFocusLock`

### DIFF
--- a/src/UI.tsx
+++ b/src/UI.tsx
@@ -24,6 +24,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
       sideCar,
       className,
       shouldIgnore,
+      focusOptions,
       style,
       as,
       ...rest
@@ -58,6 +59,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
           className={className}
           whiteList={shouldIgnore}
           lockProps={appliedLockProps}
+          focusOptions={focusOptions}
           as={RemoveScroll}
         >
           {children}

--- a/src/UI.tsx
+++ b/src/UI.tsx
@@ -24,7 +24,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
       sideCar,
       className,
       shouldIgnore,
-      focusOptions,
+      preventScrollOnFocus,
       style,
       as,
       ...rest
@@ -59,7 +59,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
           className={className}
           whiteList={shouldIgnore}
           lockProps={appliedLockProps}
-          focusOptions={focusOptions}
+          focusOptions={preventScrollOnFocus ? { preventScroll: true } : undefined}
           as={RemoveScroll}
         >
           {children}

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,11 +81,10 @@ export interface ReactFocusOnProps extends CommonProps {
    */
   returnFocus?: ComponentProps<typeof ReactFocusLock>['returnFocus'] | undefined;
   /**
-   * [focus-lock] control focusOptions
-   * @default undefined
-   * @see {@link https://github.com/theKashey/react-focus-lock/issues/162}
+   * [focus-lock] prevents scroll on focus via focusOptions
+   * @default false
    */
-  focusOptions?: ComponentProps<typeof ReactFocusLock>['focusOptions'] | undefined;
+  preventScrollOnFocus?: boolean | undefined;
   /**
    * [focus-lock] allows "ignoring" focus on some elements
    * @see {@link https://github.com/theKashey/react-focus-lock#api}

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,12 @@ export interface ReactFocusOnProps extends CommonProps {
    * @default true
    */
   returnFocus?: ComponentProps<typeof ReactFocusLock>['returnFocus'] | undefined;
-
+  /**
+   * [focus-lock] control focusOptions
+   * @default undefined
+   * @see {@link https://github.com/theKashey/react-focus-lock/issues/162}
+   */
+  focusOptions?: ComponentProps<typeof ReactFocusLock>['focusOptions'] | undefined;
   /**
    * [focus-lock] allows "ignoring" focus on some elements
    * @see {@link https://github.com/theKashey/react-focus-lock#api}


### PR DESCRIPTION
closes https://github.com/theKashey/react-focus-on/issues/62

As of [2.7.0](https://github.com/theKashey/react-focus-lock/blob/master/CHANGELOG.md#270-2021-12-12), react-focus-lock has supported a `focusOptions` prop, primarily for allowing consumers to pass `preventScroll` to the initial focus event. react-focus-on unfortunately has not exposed passing that prop directly to `react-focus-lock`, which potentially leads to scroll jumping issues that cannot be overridden (see https://github.com/theKashey/react-focus-lock/issues/162 for more info).

I looked but couldn't see any meaningful unit tests to write/update to include this new prop - please feel free to ping me if there are!