### PR TITLE
bump react-focus-lock version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,258 +1,39 @@
-# [3.8.0](https://github.com/theKashey/react-focus-on/compare/v3.7.0...v3.8.0) (2023-03-16)
-
-
-### Bug Fixes
-
-* wire up gapMode, fixes [#65](https://github.com/theKashey/react-focus-on/issues/65) ([455fda9](https://github.com/theKashey/react-focus-on/commit/455fda9))
-
-
-
-# [3.7.0](https://github.com/theKashey/react-focus-on/compare/v3.6.0...v3.7.0) (2022-11-13)
-
-
-### Bug Fixes
-
-* update dependnecies ([3f836ef](https://github.com/theKashey/react-focus-on/commit/3f836ef))
-
-
-
-# [3.6.0](https://github.com/theKashey/react-focus-on/compare/v3.5.4...v3.6.0) (2022-05-01)
-
-
-### Bug Fixes
-
-* update underlaying packages; brings React 18 and Shadow DOM support ([5bd7b5c](https://github.com/theKashey/react-focus-on/commit/5bd7b5c))
-
-
-
-## [3.5.4](https://github.com/theKashey/react-focus-on/compare/v3.5.3...v3.5.4) (2021-11-09)
-
-
-
-## [3.5.3](https://github.com/theKashey/react-focus-on/compare/v3.5.2...v3.5.3) (2021-11-09)
+## 3.8.1 (2023-06-19)
 
 
 ### Bug Fixes
 
 * add tslib as dependency, fixes [#54](https://github.com/theKashey/react-focus-on/issues/54) ([ce204cd](https://github.com/theKashey/react-focus-on/commit/ce204cd))
-
-
-
-## [3.5.2](https://github.com/theKashey/react-focus-on/compare/v3.5.1...v3.5.2) (2021-03-28)
-
-
-
-## [3.5.1](https://github.com/theKashey/react-focus-on/compare/v3.5.0...v3.5.1) (2020-11-27)
-
-
-
-# [3.5.0](https://github.com/theKashey/react-focus-on/compare/v3.4.1...v3.5.0) (2020-08-13)
+* aria-hidden broken in v3, fixes [#8](https://github.com/theKashey/react-focus-on/issues/8) ([f7570e5](https://github.com/theKashey/react-focus-on/commit/f7570e5))
+* deactivation sequence, fixes [#24](https://github.com/theKashey/react-focus-on/issues/24) ([32ed7d7](https://github.com/theKashey/react-focus-on/commit/32ed7d7))
+* dont prevent internal clicks, fixes [#3](https://github.com/theKashey/react-focus-on/issues/3) ([229eaad](https://github.com/theKashey/react-focus-on/commit/229eaad))
+* Escape on body ([e551925](https://github.com/theKashey/react-focus-on/commit/e551925))
+* expose returnFocus prop, fixes [#11](https://github.com/theKashey/react-focus-on/issues/11) ([b25b5b5](https://github.com/theKashey/react-focus-on/commit/b25b5b5))
+* fixes onClickOutside on iOS devices. fixes [#13](https://github.com/theKashey/react-focus-on/issues/13) ([96d0756](https://github.com/theKashey/react-focus-on/commit/96d0756))
+* handle Esc in IE compatible way, fixes [#10](https://github.com/theKashey/react-focus-on/issues/10) ([f897bea](https://github.com/theKashey/react-focus-on/commit/f897bea))
+* return focus by default ([a525b4c](https://github.com/theKashey/react-focus-on/commit/a525b4c))
+* update dependnecies ([3f836ef](https://github.com/theKashey/react-focus-on/commit/3f836ef))
+* update focus-lock, fixes [#35](https://github.com/theKashey/react-focus-on/issues/35) ([280d4a5](https://github.com/theKashey/react-focus-on/commit/280d4a5))
+* update hooks when users changes callbacks, fixes [#17](https://github.com/theKashey/react-focus-on/issues/17) ([127a303](https://github.com/theKashey/react-focus-on/commit/127a303))
+* update react-remove-scroll, fixes [#65](https://github.com/theKashey/react-focus-on/issues/65) ([e07d6ca](https://github.com/theKashey/react-focus-on/commit/e07d6ca))
+* update underlaying packages; brings React 18 and Shadow DOM support ([5bd7b5c](https://github.com/theKashey/react-focus-on/commit/5bd7b5c))
+* wire up gapMode, fixes [#65](https://github.com/theKashey/react-focus-on/issues/65) ([455fda9](https://github.com/theKashey/react-focus-on/commit/455fda9))
 
 
 ### Features
 
 * add 'as' and 'style' props ([d1a79e4](https://github.com/theKashey/react-focus-on/commit/d1a79e4))
-* expose whitelist prop ([fa5fe87](https://github.com/theKashey/react-focus-on/commit/fa5fe87))
-
-
-
-## [3.4.1](https://github.com/theKashey/react-focus-on/compare/v3.4.0...v3.4.1) (2020-04-17)
-
-
-### Bug Fixes
-
-* update focus-lock, fixes [#35](https://github.com/theKashey/react-focus-on/issues/35) ([280d4a5](https://github.com/theKashey/react-focus-on/commit/280d4a5))
-
-
-
-# [3.4.0](https://github.com/theKashey/react-focus-on/compare/v3.3.0...v3.4.0) (2020-04-16)
-
-
-### Features
-
-* support CSP ([67739a4](https://github.com/theKashey/react-focus-on/commit/67739a4))
-
-
-
-# [3.3.0](https://github.com/theKashey/react-focus-on/compare/v3.2.0...v3.3.0) (2019-10-17)
-
-
-### Features
-
 * add allowPinchZoom ([ad396d7](https://github.com/theKashey/react-focus-on/commit/ad396d7))
-
-
-
-# [3.2.0](https://github.com/theKashey/react-focus-on/compare/v3.1.5...v3.2.0) (2019-10-13)
-
-
-### Features
-
 * allow ref forwarding ([d379b3c](https://github.com/theKashey/react-focus-on/commit/d379b3c))
-
-
-
-## [3.1.5](https://github.com/theKashey/react-focus-on/compare/v3.1.4...v3.1.5) (2019-10-06)
-
-
-
-## [3.1.4](https://github.com/theKashey/react-focus-on/compare/v3.1.3...v3.1.4) (2019-10-05)
-
-
-
-## [3.1.3](https://github.com/theKashey/react-focus-on/compare/v3.1.2...v3.1.3) (2019-10-01)
-
-
-### Bug Fixes
-
-* deactivation sequence, fixes [#24](https://github.com/theKashey/react-focus-on/issues/24) ([32ed7d7](https://github.com/theKashey/react-focus-on/commit/32ed7d7))
-
-
-
-## [3.1.2](https://github.com/theKashey/react-focus-on/compare/v3.1.1...v3.1.2) (2019-09-28)
-
-
-
-## [3.1.1](https://github.com/theKashey/react-focus-on/compare/v3.1.0...v3.1.1) (2019-09-21)
-
-
-### Bug Fixes
-
-* update hooks when users changes callbacks, fixes [#17](https://github.com/theKashey/react-focus-on/issues/17) ([127a303](https://github.com/theKashey/react-focus-on/commit/127a303))
-
-
-
-# [3.1.0](https://github.com/theKashey/react-focus-on/compare/v3.0.7...v3.1.0) (2019-09-13)
-
-
-### Features
-
-* support returnOption=preventScroll FocusLock option ([ff2dad3](https://github.com/theKashey/react-focus-on/commit/ff2dad3))
-
-
-
-## [3.0.7](https://github.com/theKashey/react-focus-on/compare/v3.0.6...v3.0.7) (2019-09-11)
-
-
-
-## [3.0.6](https://github.com/theKashey/react-focus-on/compare/v3.0.5...v3.0.6) (2019-08-15)
-
-
-### Bug Fixes
-
-* fixes onClickOutside on iOS devices. fixes [#13](https://github.com/theKashey/react-focus-on/issues/13) ([96d0756](https://github.com/theKashey/react-focus-on/commit/96d0756))
-
-
-
-## [3.0.5](https://github.com/theKashey/react-focus-on/compare/v3.0.4...v3.0.5) (2019-07-16)
-
-
-### Bug Fixes
-
-* handle Esc in IE compatible way, fixes [#10](https://github.com/theKashey/react-focus-on/issues/10) ([f897bea](https://github.com/theKashey/react-focus-on/commit/f897bea))
-
-
-
-## [3.0.4](https://github.com/theKashey/react-focus-on/compare/v3.0.3...v3.0.4) (2019-07-16)
-
-
-### Bug Fixes
-
-* expose returnFocus prop, fixes [#11](https://github.com/theKashey/react-focus-on/issues/11) ([b25b5b5](https://github.com/theKashey/react-focus-on/commit/b25b5b5))
-
-
-
-## [3.0.3](https://github.com/theKashey/react-focus-on/compare/v3.0.1...v3.0.3) (2019-07-03)
-
-
-
-## [3.0.1](https://github.com/theKashey/react-focus-on/compare/v3.0.0...v3.0.1) (2019-07-02)
-
-
-### Bug Fixes
-
-* aria-hidden broken in v3, fixes [#8](https://github.com/theKashey/react-focus-on/issues/8) ([f7570e5](https://github.com/theKashey/react-focus-on/commit/f7570e5))
-
-
-
-# [3.0.0](https://github.com/theKashey/react-focus-on/compare/v2.0.2...v3.0.0) (2019-06-29)
-
-
-### Features
-
+* expose gapMode ([0298cc8](https://github.com/theKashey/react-focus-on/commit/0298cc8))
+* expose whitelist prop ([fa5fe87](https://github.com/theKashey/react-focus-on/commit/fa5fe87))
 * introduce sidecar ([0588039](https://github.com/theKashey/react-focus-on/commit/0588039))
-
-
-
-## [2.0.2](https://github.com/theKashey/react-focus-on/compare/v2.0.1...v2.0.2) (2019-05-05)
-
-
-
-## [2.0.1](https://github.com/theKashey/react-focus-on/compare/v2.0.0...v2.0.1) (2019-04-10)
-
-
-### Bug Fixes
-
-* dont prevent internal clicks, fixes [#3](https://github.com/theKashey/react-focus-on/issues/3) ([229eaad](https://github.com/theKashey/react-focus-on/commit/229eaad))
-
-
-
-# [2.0.0](https://github.com/theKashey/react-focus-on/compare/v1.3.2...v2.0.0) (2019-03-11)
-
-
-### Features
-
+* onClickOutside event ([ed4d62b](https://github.com/theKashey/react-focus-on/commit/ed4d62b))
+* onEscapeKey ([7fb17d7](https://github.com/theKashey/react-focus-on/commit/7fb17d7))
 * shards and remove-scroll ([dbd4d5f](https://github.com/theKashey/react-focus-on/commit/dbd4d5f))
 * shards and remove-scroll ([0f5d421](https://github.com/theKashey/react-focus-on/commit/0f5d421))
-
-
-
-## [1.3.2](https://github.com/theKashey/react-focus-on/compare/v1.3.1...v1.3.2) (2019-01-21)
-
-
-### Bug Fixes
-
-* return focus by default ([a525b4c](https://github.com/theKashey/react-focus-on/commit/a525b4c))
-
-
-
-## [1.3.1](https://github.com/theKashey/react-focus-on/compare/v1.3.0...v1.3.1) (2018-12-31)
-
-
-### Bug Fixes
-
-* Escape on body ([e551925](https://github.com/theKashey/react-focus-on/commit/e551925))
-
-
-
-# [1.3.0](https://github.com/theKashey/react-focus-on/compare/v1.2.1...v1.3.0) (2018-11-13)
-
-
-### Features
-
-* expose gapMode ([0298cc8](https://github.com/theKashey/react-focus-on/commit/0298cc8))
-
-
-
-## [1.2.1](https://github.com/theKashey/react-focus-on/compare/v1.2.0...v1.2.1) (2018-11-13)
-
-
-
-# [1.2.0](https://github.com/theKashey/react-focus-on/compare/v1.1.0...v1.2.0) (2018-11-12)
-
-
-### Features
-
-* onEscapeKey ([7fb17d7](https://github.com/theKashey/react-focus-on/commit/7fb17d7))
-
-
-
-# [1.1.0](https://github.com/theKashey/react-focus-on/compare/ed4d62b...v1.1.0) (2018-11-07)
-
-
-### Features
-
-* onClickOutside event ([ed4d62b](https://github.com/theKashey/react-focus-on/commit/ed4d62b))
+* support CSP ([67739a4](https://github.com/theKashey/react-focus-on/commit/67739a4))
+* support returnOption=preventScroll FocusLock option ([ff2dad3](https://github.com/theKashey/react-focus-on/commit/ff2dad3))
 
 
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "aria-hidden": "^1.2.2",
-    "react-focus-lock": "^2.9.2",
+    "react-focus-lock": "^2.9.4",
     "react-remove-scroll": "^2.5.6",
     "react-style-singleton": "^2.2.0",
     "tslib": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4547,10 +4547,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-focus-lock@^0.11.2:
-  version "0.11.3"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/focus-lock/-/focus-lock-0.11.3.tgz#c094e8f109d780f56038abdeec79328fd56b627f"
-  integrity sha512-4n0pYcPTa/uI7Q66BZna61nRT7lDhnuJ9PJr6wiDjx4uStg491ks41y7uOG+s0umaaa+hulNKSldU9aTg9/yVg==
+focus-lock@^0.11.6:
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.6.tgz#e8821e21d218f03e100f7dc27b733f9c4f61e683"
+  integrity sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==
   dependencies:
     tslib "^2.0.3"
 
@@ -8481,13 +8481,13 @@ react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-focus-lock@^2.9.2:
-  version "2.9.2"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/react-focus-lock/-/react-focus-lock-2.9.2.tgz#a57dfd7c493e5a030d87f161c96ffd082bd920f2"
-  integrity sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==
+react-focus-lock@^2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.4.tgz#4753f6dcd167c39050c9d84f9c63c71b3ff8462e"
+  integrity sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.11.2"
+    focus-lock "^0.11.6"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.6"
     use-callback-ref "^1.3.0"


### PR DESCRIPTION
`react-focus-on` have a dependency on `react-focus-lock` which relies on `focus-lock`. 

There is a bug in [focus-lock":"0.11.5](https://github.com/theKashey/react-focus-lock/issues/241) which causes unit tests to fail with no shadowroot error in
next.js frameworks. The issue is resolved in `focus-lock@0.11.6`, but requires  bumping `react-focus-lock@2.9.4` to resolve the issue in this package.



[closes 70](https://github.com/theKashey/react-focus-on/issues/70) 