### PR TITLE
Add explicit `crossFrame` support for `ReactFocusLock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ import {FocusOn} from 'react-focus-on';
  - `[autoFocus=true]` - enables or disables `auto focus` management (see [react-focus-lock documentation](https://github.com/theKashey/react-focus-lock))
  - `[returnFocus=true]` - enables or disables `return focus` on lock deactivation (see [react-focus-lock documentation](https://github.com/theKashey/react-focus-lock))
  - `[whiteList=fn]` - you could whitelist locations FocusLock should carry about. Everything outside it will ignore. For example - any modals (see [react-focus-lock documentation](https://github.com/theKashey/react-focus-lock))
+ - `[crossFrame=true]` - enables or disables cross frame focus trapping. Setting this to false allows focus to move outside iframes (see [react-focus-lock issue](https://github.com/theKashey/react-focus-lock/issues/104))
 ---
  - `[gapMode]` - the way removed ScrollBar would be _compensated_ - margin(default), or padding. See [scroll-locky documentation](https://github.com/theKashey/react-scroll-locky#gap-modes) to find the one you need.
  - `[noIsolation]` - disables aria-hidden isolation

--- a/src/UI.tsx
+++ b/src/UI.tsx
@@ -15,6 +15,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
       children,
       autoFocus,
       shards,
+      crossFrame,
       enabled = true,
       scrollLock = true,
       focusLock = true,
@@ -61,6 +62,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
           returnFocus={returnFocus}
           autoFocus={autoFocus}
           shards={shards}
+          crossFrame={crossFrame}
           onActivation={onActivation}
           onDeactivation={onDeactivation}
           className={className}

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,11 @@ export interface ReactFocusOnProps extends CommonProps {
    */
   preventScrollOnFocus?: boolean | undefined;
   /**
+   * [focus-lock] enables aggressive focus capturing within iframes
+   * @default true
+   */
+  crossFrame?: boolean | undefined;
+  /**
    * [focus-lock] allows "ignoring" focus on some elements
    * @see {@link https://github.com/theKashey/react-focus-lock#api}
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,9 @@ export interface ReactFocusOnProps extends CommonProps {
    */
   preventScrollOnFocus?: boolean | undefined;
   /**
-   * [focus-lock] enables aggressive focus capturing within iframes
+   * [focus-lock] enables or disables cross-frame focus management when within an iframe.
+   * `true` means that focus will be restricted within the iframe
+   * `false` allows focus to leave the iframe and move to elements outside of it
    * @default true
    */
   crossFrame?: boolean | undefined;


### PR DESCRIPTION
closes https://github.com/theKashey/react-focus-on/issues/72

As of [2.3.0](https://github.com/theKashey/react-focus-lock/blob/master/CHANGELOG.md#230-2020-04-17), `react-focus-lock` has supported a `crossFrame` prop which allows focus to escape to outside iframes when `false`.

`react-focus-on` currently does not expose passing that prop directly to `react-focus-lock`, but we'd really appreciate that support being added 🙏 

Please let me know if I'm missing any docs or tests in this PR!