### PR TITLE
Fix react-focus-trap resetting focus when preventScrollOnFocus is used

### DIFF
--- a/src/UI.tsx
+++ b/src/UI.tsx
@@ -32,25 +32,33 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
       ...rest
     } = props;
 
+    // Don't let focusOptions object change reference on each render.
+    // It causes react-clientside-effect to call handleStateChangeOnClient
+    // and change focus to first focusable element inside the trap.
+    const focusOptions = React.useMemo(
+      () => (preventScrollOnFocus ? { preventScroll: true } : undefined),
+      [preventScrollOnFocus]
+    );
+
     const SideCar: SideCarComponent<EffectProps> = sideCar;
 
     const { onActivation, onDeactivation, ...restProps } = lockProps;
 
     const appliedLockProps = {
-        ...restProps,
+      ...restProps,
 
-        as,
-        style,
+      as,
+      style,
 
-        sideCar,
+      sideCar,
 
-        shards,
+      shards,
 
-        allowPinchZoom,
-        gapMode,
-        inert,
+      allowPinchZoom,
+      gapMode,
+      inert,
 
-        enabled: enabled && scrollLock,
+      enabled: enabled && scrollLock
     } as const;
 
     return (
@@ -68,7 +76,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
           className={className}
           whiteList={shouldIgnore}
           lockProps={appliedLockProps}
-          focusOptions={preventScrollOnFocus ? { preventScroll: true } : undefined}
+          focusOptions={focusOptions}
           as={RemoveScroll}
         >
           {children}


### PR DESCRIPTION
We recently received a [bug report](https://github.com/elastic/eui/issues/6848) describing an issue where react-focus-lock Trap resets focused element when previously focused element gets disabled programmatically. This is not something we expected to be happening, so I dug deep into debugger to figure out what was happening. I found that Trap is updating focus to the first element because its wrapper component (react-clientside-effect) [detects](https://github.com/theKashey/react-clientside-effect/blob/master/src/index.js#L51) any props update caused by react rerendering the tree and thus recreating the object passed to `focusOptions`:

```
focusOptions={preventScrollOnFocus ? { preventScroll: true } : undefined}
```

This PR uses `useMemo` to cache `focusOptions` value between renders and not cause react-clientside-effect to detect props change.
