### PR TITLE
fix: correct SSR for 'default-enabled' locks

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "aria-hidden": "^1.2.5",
-    "react-focus-lock": "^2.13.6",
-    "react-remove-scroll": "^2.6.3",
+    "react-focus-lock": "^2.13.7",
+    "react-remove-scroll": "^2.6.4",
     "react-style-singleton": "^2.2.3",
     "tslib": "^2.3.1",
     "use-sidecar": "^1.1.3"
@@ -78,9 +78,6 @@
     "scroll",
     "isolation"
   ],
-  "resolutions": {
-    "typescript": "^3.8.0"
-  },
   "homepage": "https://github.com/theKashey/react-focus-on#readme",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/UI.tsx
+++ b/src/UI.tsx
@@ -12,6 +12,7 @@ const PREVENT_SCROLL = { preventScroll: true };
 export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
   (props, parentRef) => {
     const [lockProps, setLockProps] = React.useState<LockProps>(false as any);
+      const [activeNode, setActiveNode] = React.useState<HTMLElement | null>(null);
 
     const {
       children,
@@ -36,10 +37,8 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
 
     const SideCar: SideCarComponent<EffectProps> = sideCar;
 
-    const { onActivation, onDeactivation, ...restProps } = lockProps;
-
     const appliedLockProps = {
-      ...restProps,
+      ...lockProps,
 
       as,
       style,
@@ -55,12 +54,20 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
       enabled: enabled && scrollLock
     } as const;
 
+      const onActivation = React.useCallback((node: HTMLElement) => {
+          setActiveNode(node);
+      }, []);
+
+      const onDeactivation = React.useCallback(() => {
+          setActiveNode(null);
+      }, []);
+
     return (
       <>
         <ReactFocusLock
           ref={parentRef}
           sideCar={sideCar}
-          disabled={!(lockProps && enabled && focusLock)}
+          disabled={!(enabled && focusLock)}
           returnFocus={returnFocus}
           autoFocus={autoFocus}
           shards={shards}
@@ -71,6 +78,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
           whiteList={shouldIgnore}
           lockProps={appliedLockProps}
           focusOptions={preventScrollOnFocus ? PREVENT_SCROLL : undefined}
+          // // ts-expect-error TS2322 - ts v3 "glitch"
           as={RemoveScroll}
         >
           {children}
@@ -81,6 +89,7 @@ export const FocusOn = React.forwardRef<HTMLElement, ReactFocusOnSideProps>(
             sideCar={effectCar}
             setLockProps={setLockProps}
             shards={shards}
+            activeNode={activeNode}
           />
         )}
       </>

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,4 +124,5 @@ export interface ReactFocusOnSideProps extends ReactFocusOnProps {
 
 export interface EffectProps extends CommonProps {
   setLockProps(settings: LockProps): void;
+  activeNode: HTMLElement | null;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8487,10 +8487,10 @@ react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-focus-lock@^2.13.6:
-  version "2.13.6"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.13.6.tgz#29751bf2e4e30f6248673cd87a347c74ff2af672"
-  integrity sha512-ehylFFWyYtBKXjAO9+3v8d0i+cnc1trGS0vlTGhzFW1vbFXVUTmR8s2tt/ZQG8x5hElg6rhENlLG1H3EZK0Llg==
+react-focus-lock@^2.13.7:
+  version "2.13.7"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.13.7.tgz#2f51ad417e4212a9f7bdd87da092aa2ad0536d5a"
+  integrity sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==
   dependencies:
     "@babel/runtime" "^7.0.0"
     focus-lock "^1.3.6"
@@ -8539,10 +8539,10 @@ react-remove-scroll-bar@^2.3.7:
     react-style-singleton "^2.2.2"
     tslib "^2.0.0"
 
-react-remove-scroll@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz#df02cde56d5f2731e058531f8ffd7f9adec91ac2"
-  integrity sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==
+react-remove-scroll@^2.6.4:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
+  integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
   dependencies:
     react-remove-scroll-bar "^2.3.7"
     react-style-singleton "^2.2.3"
@@ -10248,7 +10248,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.2.1, typescript@^3.5.2, typescript@^3.8.0:
+typescript@^3.2.1, typescript@^3.5.2:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==


### PR DESCRIPTION
Followup for https://github.com/theKashey/react-focus-lock/issues/377 reported by @ExLineP where "toggle" around `disabled` causes context instability.

In this case Lock initialization is delayed by a sidecar load, but only to inject custom `onActivation` callback which is only required to kick off `aria-hidden`. This process can be performed in parallel.

- simpler logic
- no race conditions
- no updates to context due to "two step" initialisation

> Extracted from https://github.com/theKashey/react-focus-on/pull/109